### PR TITLE
Fix: Ensure project ID is provided for S3 deployment URL retrieval

### DIFF
--- a/src/api/deploy-app/deploy-app.service.ts
+++ b/src/api/deploy-app/deploy-app.service.ts
@@ -181,8 +181,11 @@ export class DeployAppService {
   }
 
   async getS3DeploymentUrl(projectId: string) {
+    if (!projectId) {
+      throw new NotFoundException("Project ID is required");
+    }
     const s3Deployment = await this.s3DeploymentRepository.findOne(
-      { where: {projectId: projectId }}
+      { where: { projectId: projectId }}
     );
     if (!s3Deployment) {
       throw new NotFoundException("Project not found or is not deployed yet");


### PR DESCRIPTION
Now when no project ID is provided, server always returns default project.
<img width="639" alt="image" src="https://github.com/user-attachments/assets/f8f78ce3-70f8-4bc7-ac37-bd085b898ed3" />
New behaviour when no project id has been provided:
<img width="387" alt="image" src="https://github.com/user-attachments/assets/c22454ca-a1ae-4e21-9a4c-41f190d3ddf8" />
