### PR TITLE
Feature/pending messages

### DIFF
--- a/db/migrations/1753797810757-add-pending-messages-to-user.ts
+++ b/db/migrations/1753797810757-add-pending-messages-to-user.ts
@@ -1,0 +1,14 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class  AddPendingMessagesToUser1753797810757 implements MigrationInterface {
+    name = ' $addPendingMessagesToUser1753797810757'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "user" ADD "pendingMessages" integer NOT NULL DEFAULT '0'`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "user" DROP COLUMN "pendingMessages"`);
+    }
+
+}

--- a/db/migrations/1753797810757-add-pending-messages-to-user.ts
+++ b/db/migrations/1753797810757-add-pending-messages-to-user.ts
@@ -1,7 +1,7 @@
 import { MigrationInterface, QueryRunner } from "typeorm";
 
 export class  AddPendingMessagesToUser1753797810757 implements MigrationInterface {
-    name = ' $addPendingMessagesToUser1753797810757'
+    name = 'AddPendingMessagesToUser1753797810757'
 
     public async up(queryRunner: QueryRunner): Promise<void> {
         await queryRunner.query(`ALTER TABLE "user" ADD "pendingMessages" integer NOT NULL DEFAULT '0'`);

--- a/src/api/auth/auth.service.ts
+++ b/src/api/auth/auth.service.ts
@@ -61,6 +61,7 @@ export class AuthService {
       id: user.id,
       wallet: user.wallet,
       messagesLeft: user.messagesLeft,
+      pendingMessages: user.pendingMessages,
       inviteCode: user.inviteCode,
       discountPercent: user.discountPercent,
       referralsRewards: lamportsToSol(user.referralsRewards),

--- a/src/api/auth/response/user-me.response.ts
+++ b/src/api/auth/response/user-me.response.ts
@@ -21,6 +21,12 @@ export class UserMeResponse {
   messagesLeft: number;
 
   @ApiProperty({
+    description: 'Pending messages for the user',
+    example: 2,
+  })
+  pendingMessages: number;
+
+  @ApiProperty({
     description: 'User invite code for referrals. 6 characters long, alphanumeric (a-z, A-Z, 0-9)',
     example: 'abC123',
   })

--- a/src/api/billing/billing.controller.ts
+++ b/src/api/billing/billing.controller.ts
@@ -10,6 +10,7 @@ import { BuyForRewardsDto } from './dto/buyForRewards.dto';
 import { RewardsWithdrawalReceipt } from '../../entities/rewards-withdrawal-receipt.entity';
 import { WithdrawalReceiptResponse } from './response/withdrawal-reciept.response';
 import { FundReceiptResponse } from './response/fund-receipt.response';
+import { PendingMessagesResponse } from './response/pending-messages.response';
 
 
 // type WithdrawalReceiptResponse = Omit<RewardsWithdrawalReceipt, 'user' | 'userId'>;
@@ -33,6 +34,18 @@ export class BillingController {
   @ApiBearerAuth()
   async decrementMessagesLeft(@ApiContext() user: User): Promise<MessagesLeftResponse> {
     return this.billingService.decrementMessagesLeft(user);
+  }
+
+  @Post('decrement-pending-messages')
+  @ApiBearerAuth()
+  async decrementPendingMessages(@ApiContext() user: User): Promise<PendingMessagesResponse> {
+    return this.billingService.decrementPendingMessages(user);
+  }
+
+  @Post('increment-pending-messages')
+  @ApiBearerAuth()
+  async incrementPendingMessages(@ApiContext() user: User): Promise<PendingMessagesResponse> {
+    return this.billingService.incrementPendingMessages(user);
   }
 
   @Post('buy-for-rewards')

--- a/src/api/billing/billing.service.ts
+++ b/src/api/billing/billing.service.ts
@@ -133,6 +133,9 @@ export class BillingService {
   }
 
   async incrementPendingMessages(user: User): Promise<PendingMessagesResponse> {
+    if (user.pendingMessages >= user.messagesLeft){
+      throw new BadRequestException('Cannot increment pending messages, user has no messages left');
+    }
     user.pendingMessages += 1;
     await this.userRepository.save(user);
     return { pendingMessages: user.pendingMessages };

--- a/src/api/billing/billing.service.ts
+++ b/src/api/billing/billing.service.ts
@@ -22,6 +22,7 @@ import { Connection, Keypair, PublicKey, sendAndConfirmTransaction, SystemProgra
 import bs58 from 'bs58';
 import { WithdrawalReceiptResponse } from './response/withdrawal-reciept.response';
 import { FundReceiptResponse } from './response/fund-receipt.response';
+import { PendingMessagesResponse } from './response/pending-messages.response';
 
 @Injectable()
 export class BillingService {
@@ -120,6 +121,21 @@ export class BillingService {
     await this.userRepository.save(user);
 
     return { messagesLeft: user.messagesLeft };
+  }
+
+  async decrementPendingMessages(user: User): Promise<PendingMessagesResponse>{
+    user.pendingMessages -= 1;
+    if (user.pendingMessages < 0) {
+      throw new BadRequestException('Pending messages cannot be negative');
+    }
+    await this.userRepository.save(user);
+    return { pendingMessages: user.pendingMessages };
+  }
+
+  async incrementPendingMessages(user: User): Promise<PendingMessagesResponse> {
+    user.pendingMessages += 1;
+    await this.userRepository.save(user);
+    return { pendingMessages: user.pendingMessages };
   }
 
   private async updateUserMessagesLeft(userId: string, solAmountPaid: number) {

--- a/src/api/billing/billing.service.ts
+++ b/src/api/billing/billing.service.ts
@@ -133,7 +133,7 @@ export class BillingService {
   }
 
   async incrementPendingMessages(user: User): Promise<PendingMessagesResponse> {
-    if (user.pendingMessages >= user.messagesLeft){
+    if (user.pendingMessages + 1 > user.messagesLeft){
       throw new BadRequestException('Cannot increment pending messages, user has no messages left');
     }
     user.pendingMessages += 1;

--- a/src/api/billing/response/pending-messages.response.ts
+++ b/src/api/billing/response/pending-messages.response.ts
@@ -1,0 +1,9 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class PendingMessagesResponse {
+  @ApiProperty({
+    description: 'Number of pending messages',
+    example: 10,
+  })
+  pendingMessages: number;
+}

--- a/src/entities/user.entity.ts
+++ b/src/entities/user.entity.ts
@@ -28,6 +28,9 @@ export class User {
   @Column({ type: 'integer', default: 2 })
   messagesLeft: number;
 
+  @Column({ type: 'integer', default: 0 })
+  pendingMessages: number;
+
   @Unique('uq_invite_code', ['inviteCode'])
   @Column({ type: 'varchar', length: 6, nullable: false, default: () => 'randomInviteCode()' })
   inviteCode: string;


### PR DESCRIPTION
## 📄 Pull Request Description

Updated user entity by adding a field for pending messages count. Added endpoints for incrementing and decrementing pending messages with restrictions: pending messages cannot be less than zero or more than user's messagesLeft.
Also updated auth/me endpoint by adding pending messages to the user dto.

---

## ✅ Type of Change

<!-- Check the relevant option(s) below -->

- [*] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] ♻️ Refactor (non-breaking changes that improve code structure)
- [ ] 📝 Documentation update
- [ ] 🚨 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] ⚙️ Other (please describe):

---

## 🧪 Test Plan / Results

Test plan: 
Give yourself N messages, run the frontend, open N+1 tabs, and send N+1 messages to different chats. 
Pray for your PC for at least 5 minutes.
Expected result: N chats make a request to the AI model, and the last chat throws the No messages error.

Test results:
Tested with 2 tabs and 1 message at first. 
1 tab processed the request (gave AI response), the other gave the No messages error.
Tested with 3 tabs and 2 messages. 
As a result got 2 logs indicating 2 AI requests. The last tab gave the No messages error, the first two tabs gave Chat ID missing errors. My PC almost died.
There will be no screenshots, I'm not doing that again.
---

## 📋 Checklist

- [*] I've tested the feature/bug thoroughly and attached test results or screenshots.
- [*] I've added or updated necessary documentation (e.g., README, inline comments).
- [ ] I've updated or added relevant tests where needed.
- [ ] Code is formatted and linted properly.
- [ ] No console errors or warnings in the browser / logs.
- [*] All existing and new tests pass locally.
- [*] I have reviewed the code for security and performance implications.

---

## 🚀 Future steps

Hope.

---

## 💬 Additional Notes


---

## Related Issues / Tickets

Issue: if the user has N messages and tries to run N+K requests for project creation, then the user will have N+K projects, K of which will be empty.
