### PR TITLE
Added isBinary to s3Client call in upsertIcpDeployment.

### DIFF
--- a/src/api/deploy-app/deploy-app.service.ts
+++ b/src/api/deploy-app/deploy-app.service.ts
@@ -209,7 +209,7 @@ export class DeployAppService {
 
     const files = deserializeDistSnapshot(snapshot as FileMap);
     await this.s3Client.uploadProjectBuild(projectId, files.map((file) => ({
-      fileName: file.file, content: file.data
+      fileName: file.file, content: file.data, isBinary: file.isBinary
     })));
 
     const pipelineId = await this.circleCiClient.initICPDeploymentPipeline(


### PR DESCRIPTION
## 📄 Pull Request Description

Parameters of the uploadProjectBuild method of the S3Service were updated in the fix/s3-binary-files branch, causing methods for ICP deployment on the dev branch to break after merge. This PR fixes the broken method by updating the uploadProjectBuild call.

---

## ✅ Type of Change

<!-- Check the relevant option(s) below -->

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] ♻️ Refactor (non-breaking changes that improve code structure)
- [ ] 📝 Documentation update
- [ ] 🚨 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] ⚙️ Other (please describe):

---

## 🧪 Test Plan / Results

Tested by starting the project. The project compiles and launches successfully.

---

## 📋 Checklist

- [ ] I've tested the feature/bug thoroughly and attached test results or screenshots.
- [ ] I've added or updated necessary documentation (e.g., README, inline comments).
- [ ] I've updated or added relevant tests where needed.
- [ ] Code is formatted and linted properly.
- [ ] No console errors or warnings in the browser / logs.
- [ ] All existing and new tests pass locally.
- [ ] I have reviewed the code for security and performance implications.

---

## 🚀 Future steps


---

## 💬 Additional Notes


---

## Related Issues / Tickets

